### PR TITLE
minor change

### DIFF
--- a/lib/resty/upload.lua
+++ b/lib/resty/upload.lua
@@ -5,7 +5,6 @@ local sub = string.sub
 local req_socket = ngx.req.socket
 local match = string.match
 local setmetatable = setmetatable
-local error = error
 local get_headers = ngx.req.get_headers
 local type = type
 -- local print = print
@@ -28,7 +27,7 @@ local state_handlers
 
 
 local function get_boundary()
-    local header = get_headers()["content-type"]
+    local header = ngx.var.http_content_type
     if not header then
         return nil
     end
@@ -110,7 +109,7 @@ local function discard_line(self)
         return nil, err
     end
 
-    return 1
+    return line
 end
 
 
@@ -169,20 +168,9 @@ end
 
 
 local function read_header(self)
-    local read_line = self.read_line
-
-    local line, err = read_line(MAX_LINE_SIZE)
-    if err then
-        return nil, nil, err
-    end
-
-    local dummy, err = read_line(1)
-    if dummy then
-        return nil, nil, "line too long: " .. line .. dummy .. "..."
-    end
-
-    if err then
-        return nil, nil, err
+    local line, err = discard_line(self)
+    if not line then
+       return nil, nil, err
     end
 
     -- print("read line: ", line)


### PR DESCRIPTION
1. removes a useless line
2. uses ngx.var.http_content_type not ngx.req.get_headers()["content-type"]
3. The function discard_line() can be used in the read_header() function if the discard_line() can be changed so that the discard_line() function returns the “line” for the success instead of 1.