### PR TITLE
improve: removed the superfluous header type check

### DIFF
--- a/lib/resty/upload.lua
+++ b/lib/resty/upload.lua
@@ -5,7 +5,6 @@
 local req_socket = ngx.req.socket
 local match = string.match
 local setmetatable = setmetatable
-local type = type
 local ngx_var = ngx.var
 -- local print = print
 
@@ -31,10 +30,6 @@ local function get_boundary()
     local header = ngx_var.content_type
     if not header then
         return nil
-    end
-
-    if type(header) == "table" then
-        header = header[1]
     end
 
     local m = match(header, ";%s*boundary=\"([^\"]+)\"")


### PR DESCRIPTION
The ngx.var API only returns a Lua string in case of success or `nil` if
failure. So check whether the header is a Lua table is superfluous.